### PR TITLE
refactor(PID): Rename `requestedTemperature` to `requestedTemp`

### DIFF
--- a/src/PID.ts
+++ b/src/PID.ts
@@ -2,7 +2,7 @@ import { DeviceContext } from './DeviceContext';
 import { DeviceMakeModel } from './Devices';
 
 export const TemperatureContext = {
-  requestedTemperature: 195
+  requestedTemp: 195
 }
 
 export function applyRequestedTemperature(temp: number) {
@@ -10,10 +10,10 @@ export function applyRequestedTemperature(temp: number) {
 
   switch (makeAndModel) {
     case DeviceMakeModel.LUCCA_M58:
-      TemperatureContext.requestedTemperature = temp - 1;
+      TemperatureContext.requestedTemp = temp - 1;
       break;
     default:
-      TemperatureContext.requestedTemperature = temp;
+      TemperatureContext.requestedTemp = temp;
       break;
   }
 }

--- a/src/__tests__/PID.test.ts
+++ b/src/__tests__/PID.test.ts
@@ -28,12 +28,12 @@ describe("applyRequestedTemperature", () => {
 
     applyRequestedTemperature(205);
 
-    expect(TemperatureContext.requestedTemperature).toBe(204);
+    expect(TemperatureContext.requestedTemp).toBe(204);
   });
 
   it("should set temp context appropriately", () => {
     applyRequestedTemperature(205);
 
-    expect(TemperatureContext.requestedTemperature).toBe(205);
+    expect(TemperatureContext.requestedTemp).toBe(205);
   });
 });


### PR DESCRIPTION
<!-- 👋 Hey! Thanks for submitting a PR. Please follow the template below so we can better understand what this PR changes! -->

<!-- UNCOMMENT BELOW if related to an issue -->
<!-- Closes #[issue] -->

Rename to remove some redundancy in the naming

## Changes

- Renamed `requestedTemperature` to `requestedTemp` in `PID`
